### PR TITLE
seek cursor fix

### DIFF
--- a/dcos-log/journal/reader/read.go
+++ b/dcos-log/journal/reader/read.go
@@ -136,10 +136,6 @@ func (r *Reader) SeekCursor(c string) error {
 		return fmt.Errorf("Cursor %s not found: %s", c, err)
 	}
 
-	// now if we found the cursor, let's move it a step back to the original position
-	if _, err := r.Journal.Previous(); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
when we seek for the cursor, we expected that the next entry will be right
after the cursor position we used in request.