### PR TITLE
dcos-log bug fixes

### DIFF
--- a/dcos-log/api/handlers_test.go
+++ b/dcos-log/api/handlers_test.go
@@ -383,7 +383,7 @@ func contains(s []string, v string) bool {
 }
 
 func TestDownloadHandler(t *testing.T) {
-	w, err := newRequest("/range/", map[string]string{"Accept": "application/json"}, "POST")
+	w, err := newRequest("/range/download", map[string]string{"Accept": "application/json"}, "GET")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dcos-log/api/middleware.go
+++ b/dcos-log/api/middleware.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-go/dcos/nodeutil"
@@ -198,12 +197,19 @@ func downloadGzippedContentMiddleware(next http.Handler, prefix string, vars ...
 			}
 		}
 
+		// get user provided postfix
+		if err := r.ParseForm(); err == nil {
+			if postfix := r.Form.Get("postfix"); postfix != "" {
+				filenameParts = append(filenameParts, postfix)
+			}
+		}
+
 		filename := strings.Join(filenameParts, "-")
 		if filename == "" {
 			filename = "download"
 		}
 
-		f := fmt.Sprintf("%s-%d.log.gz", filename, time.Now().UnixNano())
+		f := fmt.Sprintf("%s.log.gz", filename)
 		w.Header().Add("Content-disposition", "attachment; filename="+f)
 		gz := gzip.NewWriter(w)
 		defer gz.Close()

--- a/dcos-log/api/routes.go
+++ b/dcos-log/api/routes.go
@@ -45,10 +45,10 @@ func newAPIRouter(cfg *config.Config, client *http.Client, nodeInfo nodeutil.Nod
 	logsRange.Path("/framework/{framework_id}/executor/{executor_id}/container/{container_id}").
 		Handler(newAuthMiddleware(handler)).Methods("GET")
 
-	// POST added download headers
-	logsRange.Path("/").Handler(downloadGzippedContentMiddleware(handler, "root-range")).Methods("POST")
-	logsRange.Path("/framework/{framework_id}/executor/{executor_id}/container/{container_id}").
-		Handler(newAuthMiddleware(downloadGzippedContentMiddleware(handler, "app", "container_id"))).Methods("POST")
+	// added download headers
+	logsRange.Path("/download").Handler(downloadGzippedContentMiddleware(handler, "root-range")).Methods("GET")
+	logsRange.Path("/framework/{framework_id}/executor/{executor_id}/container/{container_id}/download").
+		Handler(newAuthMiddleware(downloadGzippedContentMiddleware(handler, "task", "container_id"))).Methods("GET")
 
 	logsStream := r.PathPrefix("/stream").Subrouter()
 	logsStream.Path("/").Handler(streamMiddleware(handler)).Methods("GET")


### PR DESCRIPTION
 - change log line format to `timestamp MESSAGE`
 - change use /download postfix to download logs with GET request
 - add `postfix` get parameter to let the user pass a postfix for log file
   (should be used to separate stdout from stderr)