### PR TITLE
add response header X-Accel-Buffering

### DIFF
--- a/dcos-log/api/handlers.go
+++ b/dcos-log/api/handlers.go
@@ -280,6 +280,7 @@ func readJournalHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Accel-Buffering", "no")
 	f := w.(http.Flusher)
 	notify := w.(http.CloseNotifier).CloseNotify()
 


### PR DESCRIPTION
for server sent events add X-Accel-Buffering: no in response
https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate/801629#801629