### PR TITLE
add dcos-log v2 API

### DIFF
--- a/dcos-log/api/middleware/auth.go
+++ b/dcos-log/api/middleware/auth.go
@@ -68,8 +68,8 @@ func GetAuthFromRequest(r *http.Request) (string, error) {
 	return "", ErrMissingToken
 }
 
-// AuthMiddleware is a middleware that validates a user has a valid JWT to access the given endpoint.
-func AuthMiddleware(next http.Handler, client *http.Client, nodeInfo nodeutil.NodeInfo, role string) http.Handler {
+// Auth is a middleware that validates a user has a valid JWT to access the given endpoint.
+func Auth(next http.Handler, client *http.Client, nodeInfo nodeutil.NodeInfo, role string) http.Handler {
 	if nodeInfo == nil {
 		panic("nodeInfo cannot be nil")
 	}

--- a/dcos-log/api/middleware/download.go
+++ b/dcos-log/api/middleware/download.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"compress/gzip"
+	"github.com/gorilla/mux"
+)
+
+// Gzip Compression
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+// DownloadGzippedContent is a middleware which sets Content-disposition header and makes a postfix
+// for a downloadable item.
+func DownloadGzippedContent(next http.Handler, prefix string, vars ...string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// log name lazy evaluation
+		filenameParts := []string{prefix}
+		muxVars := mux.Vars(r)
+		for _, v := range vars {
+			if muxVar := muxVars[v]; muxVar != "" {
+				filenameParts = append(filenameParts, muxVar)
+			}
+		}
+
+		// get user provided postfix
+		if err := r.ParseForm(); err == nil {
+			if postfix := r.Form.Get("postfix"); postfix != "" {
+				filenameParts = append(filenameParts, postfix)
+			}
+		}
+
+		filename := strings.Join(filenameParts, "-")
+		if filename == "" {
+			filename = "download"
+		}
+
+		f := fmt.Sprintf("%s.log.gz", filename)
+		w.Header().Add("Content-disposition", "attachment; filename="+f)
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		gzw := gzipResponseWriter{Writer: gz, ResponseWriter: w}
+		next.ServeHTTP(gzw, r)
+	})
+}

--- a/dcos-log/api/middleware/mesos.go
+++ b/dcos-log/api/middleware/mesos.go
@@ -11,11 +11,11 @@ import (
 
 type key int
 
-var (
-	cfgKey        key
-	httpClientKey key = 1
-	nodeInfoKey   key = 2
-	tokenKey      key = 3
+const (
+	cfgKey key = key(iota)
+	httpClientKey
+	nodeInfoKey
+	tokenKey
 )
 
 // withKeyContext returns a context with an encapsulated object by a key.

--- a/dcos-log/api/middleware/mesos.go
+++ b/dcos-log/api/middleware/mesos.go
@@ -1,0 +1,109 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"github.com/dcos/dcos-log/dcos-log/config"
+)
+
+type key int
+
+var (
+	cfgKey        key
+	httpClientKey key = 1
+	nodeInfoKey   key = 2
+	tokenKey      key = 3
+)
+
+// withKeyContext returns a context with an encapsulated object by a key.
+func withKeyContext(ctx context.Context, k key, obj interface{}) context.Context {
+	return context.WithValue(ctx, k, obj)
+}
+
+// fromKeyContext returns an object from a context by a key.
+func fromContextByKey(ctx context.Context, k key) (interface{}, bool) {
+	instance := ctx.Value(k)
+	return instance, instance != nil
+}
+
+// WithConfigContext wraps a config object into context.
+func WithConfigContext(ctx context.Context, cfg *config.Config) context.Context {
+	return withKeyContext(ctx, cfgKey, cfg)
+}
+
+// FromContextConfig returns a config object from a context
+func FromContextConfig(ctx context.Context) (cfg *config.Config, ok bool) {
+	instance, ok := fromContextByKey(ctx, cfgKey)
+	if !ok {
+		return nil, ok
+	}
+
+	cfg, ok = instance.(*config.Config)
+	return cfg, ok
+}
+
+// WithHTTPClientContext wraps a *http.Client object into context.
+func WithHTTPClientContext(ctx context.Context, client *http.Client) context.Context {
+	return withKeyContext(ctx, httpClientKey, client)
+}
+
+// FromContextHTTPClient returns an *http.Client object from a context
+func FromContextHTTPClient(ctx context.Context) (client *http.Client, ok bool) {
+	instance, ok := fromContextByKey(ctx, httpClientKey)
+	if !ok {
+		return nil, ok
+	}
+
+	client, ok = instance.(*http.Client)
+	return client, ok
+}
+
+// WithNodeInfoContext wraps the NodeInfo object into context.
+func WithNodeInfoContext(ctx context.Context, nodeInfo nodeutil.NodeInfo) context.Context {
+	return withKeyContext(ctx, nodeInfoKey, nodeInfo)
+}
+
+// FromContextNodeInfo returns a nodeInfo object from a context.
+func FromContextNodeInfo(ctx context.Context) (nodeInfo nodeutil.NodeInfo, ok bool) {
+	instance, ok := fromContextByKey(ctx, nodeInfoKey)
+	if !ok {
+		return nil, ok
+	}
+
+	nodeInfo, ok = instance.(nodeutil.NodeInfo)
+	return nodeInfo, ok
+}
+
+// FromContextToken returns a token string from a context if available.
+func FromContextToken(ctx context.Context) (string, bool) {
+	instance, ok := fromContextByKey(ctx, tokenKey)
+	if !ok {
+		return "", ok
+	}
+
+	token, ok := instance.(*string)
+	return *token, ok
+}
+
+// Wrapped wraps an http handler with values in a context.
+func Wrapped(next http.Handler, cfg *config.Config, client *http.Client, nodeInfo nodeutil.NodeInfo) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = WithConfigContext(ctx, cfg)
+		ctx = WithHTTPClientContext(ctx, client)
+		ctx = WithNodeInfoContext(ctx, nodeInfo)
+
+		// wrap the token string is available
+		token, err := GetAuthFromRequest(r)
+		if err == nil && token != "" {
+			ctx = withKeyContext(ctx, tokenKey, &token)
+		} else {
+			logrus.Warnf("Authorization token not found: %s", err)
+		}
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/dcos-log/api/routes.go
+++ b/dcos-log/api/routes.go
@@ -5,14 +5,20 @@ import (
 
 	"github.com/dcos/dcos-go/dcos/nodeutil"
 	"github.com/dcos/dcos-log/dcos-log/api/v1"
+	"github.com/dcos/dcos-log/dcos-log/api/v2"
 	"github.com/dcos/dcos-log/dcos-log/config"
 	"github.com/gorilla/mux"
 )
 
 func newAPIRouter(cfg *config.Config, client *http.Client, nodeInfo nodeutil.NodeInfo) (*mux.Router, error) {
 	r := mux.NewRouter()
+
 	// define top level subrouter for base endpoint /v1
 	v1Subrouter := r.PathPrefix("/v1").Subrouter()
 	v1.InitRoutes(v1Subrouter, cfg, client, nodeInfo)
+
+	v2Subrouter := r.PathPrefix("/v2").Subrouter()
+	v2.InitRoutes(v2Subrouter, cfg, client, nodeInfo)
+
 	return r, nil
 }

--- a/dcos-log/api/server.go
+++ b/dcos-log/api/server.go
@@ -24,12 +24,13 @@ var defaultStateURL = url.URL{
 }
 
 func newNodeInfo(cfg *config.Config, client *http.Client) (nodeutil.NodeInfo, error) {
+	stateURL := defaultStateURL
 	if !cfg.FlagAuth {
-		return nil, nil
+		stateURL.Scheme = "http"
 	}
 
 	// if auth is enabled we will also make requests to mesos via https.
-	nodeInfo, err := nodeutil.NewNodeInfo(client, cfg.FlagRole, nodeutil.OptionMesosStateURL(defaultStateURL.String()))
+	nodeInfo, err := nodeutil.NewNodeInfo(client, cfg.FlagRole, nodeutil.OptionMesosStateURL(stateURL.String()))
 	if err != nil {
 		return nil, err
 	}

--- a/dcos-log/api/v1/handlers.go
+++ b/dcos-log/api/v1/handlers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-
 // AllowedFields contain `Journald Container Logger module` fields except ExecutorInfo.
 // https://github.com/dcos/dcos-mesos-modules/blob/master/journald/README.md#journald-container-logger-module
 var AllowedFields = []string{"FRAMEWORK_ID", "AGENT_ID", "EXECUTOR_ID", "CONTAINER_ID", "STREAM"}
@@ -290,7 +289,7 @@ func readJournalHandler(w http.ResponseWriter, req *http.Request) {
 		select {
 		case <-notify:
 			{
-				logrus.Debugf("Closing a client connecton.Request URI: %s", req.RequestURI)
+				logrus.Debugf("Closing a client connection.Request URI: %s", req.RequestURI)
 				return
 			}
 		case <-time.After(time.Second):
@@ -347,6 +346,6 @@ func fieldHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(v)
 	if err != nil {
-		logrus.Errorf("Error writting to client: %s", err)
+		logrus.Errorf("Error writing to client: %s", err)
 	}
 }

--- a/dcos-log/api/v1/routes.go
+++ b/dcos-log/api/v1/routes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"github.com/dcos/dcos-log/dcos-log/api/middleware"
 	"github.com/dcos/dcos-log/dcos-log/config"
 	"github.com/gorilla/mux"
 )
@@ -26,7 +27,7 @@ func InitRoutes(v1 *mux.Router, cfg *config.Config, client *http.Client, nodeInf
 
 	if cfg.FlagAuth {
 		newAuthMiddleware = func(h http.Handler) http.Handler {
-			return authMiddleware(h, client, nodeInfo, cfg.FlagRole)
+			return middleware.AuthMiddleware(h, client, nodeInfo, cfg.FlagRole)
 		}
 	}
 
@@ -43,9 +44,9 @@ func InitRoutes(v1 *mux.Router, cfg *config.Config, client *http.Client, nodeInf
 	v1.Path("/range/framework/{framework_id}/executor/{executor_id}/container/{container_id}").
 		Handler(newAuthMiddleware(handler)).Methods("GET")
 
-	v1.Path("/range/download").Handler(downloadGzippedContentMiddleware(handler, "root-range")).Methods("GET")
+	v1.Path("/range/download").Handler(middleware.DownloadGzippedContent(handler, "root-range")).Methods("GET")
 	v1.Path("/range/framework/{framework_id}/executor/{executor_id}/container/{container_id}/download").
-		Handler(newAuthMiddleware(downloadGzippedContentMiddleware(handler, "task", "container_id"))).Methods("GET")
+		Handler(newAuthMiddleware(middleware.DownloadGzippedContent(handler, "task", "container_id"))).Methods("GET")
 
 	v1.Path("/stream/").Handler(streamMiddleware(handler)).Methods("GET")
 	v1.Path("/stream/framework/{framework_id}/executor/{executor_id}/container/{container_id}").

--- a/dcos-log/api/v1/routes.go
+++ b/dcos-log/api/v1/routes.go
@@ -27,7 +27,7 @@ func InitRoutes(v1 *mux.Router, cfg *config.Config, client *http.Client, nodeInf
 
 	if cfg.FlagAuth {
 		newAuthMiddleware = func(h http.Handler) http.Handler {
-			return middleware.AuthMiddleware(h, client, nodeInfo, cfg.FlagRole)
+			return middleware.Auth(h, client, nodeInfo, cfg.FlagRole)
 		}
 	}
 

--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -8,16 +8,16 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-go/dcos/nodeutil"
 	"github.com/dcos/dcos-log/dcos-log/api/middleware"
+	jr "github.com/dcos/dcos-log/dcos-log/journal/reader"
 	"github.com/dcos/dcos-log/dcos-log/mesos/files/reader"
 	"github.com/gorilla/mux"
-	jr "github.com/dcos/dcos-log/dcos-log/journal/reader"
-	"strings"
 )
 
 const (
@@ -25,9 +25,9 @@ const (
 )
 
 const (
-	skipParam = "skip"
+	skipParam   = "skip"
 	cursorParam = "cursor"
-	limitParam = "limit"
+	limitParam  = "limit"
 	filterParam = "filter"
 
 	cursorEndParam = "END"
@@ -312,8 +312,8 @@ func journalHandler(w http.ResponseWriter, r *http.Request) {
 	entryFormatter := jr.NewEntryFormatter(acceptHeader, useSSE)
 	var (
 		cursor string
-		err error
-		opts []jr.Option
+		err    error
+		opts   []jr.Option
 	)
 
 	if componentName := mux.Vars(r)["name"]; componentName != "" {
@@ -373,7 +373,7 @@ func journalHandler(w http.ResponseWriter, r *http.Request) {
 		if cursor != "" {
 			cursor, err = url.QueryUnescape(cursor)
 			if err != nil {
-				ERROR(w, "unable to un-escape cursor parameter: " + err.Error(), http.StatusBadRequest)
+				ERROR(w, "unable to un-escape cursor parameter: "+err.Error(), http.StatusBadRequest)
 				return
 			}
 		}
@@ -424,7 +424,7 @@ func journalHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Transfer-Encoding", "chunked")
 
-	if !useSSE{
+	if !useSSE {
 		b, err := io.Copy(w, j)
 		if err != nil {
 			ERROR(w, "unable to read the journal: "+err.Error(), http.StatusInternalServerError)

--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -104,7 +104,7 @@ func filesAPIHandler(w http.ResponseWriter, req *http.Request) {
 	opts := []reader.Option{reader.OptHeaders(header)}
 
 	var limit int
-	if limitStr := req.URL.Query().Get("limit"); limitStr != "" {
+	if limitStr := req.URL.Query().Get(limitParam); limitStr != "" {
 		limit, err = strconv.Atoi(limitStr)
 		if err != nil {
 			ERROR(w, "unable to parse integer "+limitStr, http.StatusBadRequest)
@@ -117,10 +117,10 @@ func filesAPIHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	cursor := -1
-	if cursorStr := req.URL.Query().Get("cursor"); cursorStr != "" {
-		if cursorStr == "BEG" {
+	if cursorStr := req.URL.Query().Get(cursorParam); cursorStr != "" {
+		if cursorStr == cursorBegParam {
 			cursor = 0
-		} else if cursorStr == "END" {
+		} else if cursorStr == cursorEndParam {
 			opts = append(opts, reader.OptReadFromEnd())
 		} else {
 			cursor, err = strconv.Atoi(cursorStr)
@@ -136,7 +136,7 @@ func filesAPIHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var skip int
-	if skipStr := req.URL.Query().Get("skip"); skipStr != "" {
+	if skipStr := req.URL.Query().Get(skipParam); skipStr != "" {
 		skip, err = strconv.Atoi(skipStr)
 		if err != nil {
 			ERROR(w, "unable to parse integer "+skipStr, http.StatusBadRequest)

--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -1,0 +1,293 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-go/dcos"
+	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"github.com/dcos/dcos-log/dcos-log/api/middleware"
+	"github.com/dcos/dcos-log/dcos-log/mesos/files/reader"
+	"github.com/gorilla/mux"
+)
+
+const (
+	prefix = "/system/v1/agent"
+)
+
+// ERROR is a http.Error wrapper, that also emits an error to a console
+func ERROR(w http.ResponseWriter, msg string, code int) {
+	http.Error(w, msg, code)
+	logrus.Errorf("%s; http code: %d", msg, code)
+}
+
+func filesAPIHandler(w http.ResponseWriter, req *http.Request) {
+	cfg, ok := middleware.FromContextConfig(req.Context())
+	if !ok {
+		ERROR(w, "invalid context, unable to retrieve a config object", http.StatusInternalServerError)
+		return
+	}
+
+	client, ok := middleware.FromContextHTTPClient(req.Context())
+	if !ok {
+		ERROR(w, "invalid context, unable to retrieve an *http.Client object", http.StatusInternalServerError)
+		return
+	}
+
+	nodeInfo, ok := middleware.FromContextNodeInfo(req.Context())
+	if !ok {
+		ERROR(w, "invalid context, unable to retrieve a nodeInfo object", http.StatusInternalServerError)
+		return
+	}
+
+	scheme := "http"
+	if cfg.FlagAuth {
+		scheme = "https"
+	}
+
+	vars := mux.Vars(req)
+	frameworkID := vars["frameworkID"]
+	executorID := vars["executorID"]
+	containerID := vars["containerID"]
+	taskPath := vars["taskPath"]
+	file := vars["file"]
+
+	token, ok := middleware.FromContextToken(req.Context())
+	if !ok {
+		ERROR(w, "unable to get authorization header from a request", http.StatusUnauthorized)
+		return
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	mesosID, err := nodeInfo.MesosID(nodeutil.NewContextWithHeaders(ctx, header))
+	if err != nil {
+		ERROR(w, "unable to get mesosID: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ip, err := nodeInfo.DetectIP()
+	if err != nil {
+		ERROR(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	masterURL := url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(ip.String(), strconv.Itoa(dcos.PortMesosAgent)),
+		Path:   "/files/read",
+	}
+
+	opts := []reader.Option{reader.OptHeaders(header)}
+
+	var limit int
+	if limitStr := req.URL.Query().Get("limit"); limitStr != "" {
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil {
+			ERROR(w, "unable to parse integer "+limitStr, http.StatusBadRequest)
+			return
+		}
+	}
+
+	if limit > 0 {
+		opts = append(opts, reader.OptLines(limit))
+	}
+
+	cursor := -1
+	if cursorStr := req.URL.Query().Get("cursor"); cursorStr != "" {
+		if cursorStr == "BEG" {
+			cursor = 0
+		} else if cursorStr == "END" {
+			opts = append(opts, reader.OptReadFromEnd())
+		} else {
+			cursor, err = strconv.Atoi(cursorStr)
+			if err != nil {
+				ERROR(w, "unable to parse integer "+cursorStr, http.StatusBadRequest)
+				return
+			}
+
+			if cursor >= 0 {
+				opts = append(opts, reader.OptOffset(cursor))
+			}
+		}
+	}
+
+	var skip int
+	if skipStr := req.URL.Query().Get("skip"); skipStr != "" {
+		skip, err = strconv.Atoi(skipStr)
+		if err != nil {
+			ERROR(w, "unable to parse integer "+skipStr, http.StatusBadRequest)
+			return
+		}
+
+		if skip != 0 {
+			opts = append(opts, reader.OptSkip(skip))
+		}
+
+		if skip < 0 {
+			opts = append(opts, reader.OptReadDirection(reader.BottomToTop))
+		}
+	}
+
+	lastEventID := req.Header.Get("Last-Event-ID")
+	if lastEventID != "" {
+		offset, err := strconv.Atoi(lastEventID)
+		if err != nil {
+			ERROR(w, fmt.Sprintf("invalid Last-Event-ID: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		opts = append(opts, reader.OptOffset(offset))
+	}
+
+	defaultFormatter := reader.LineFormat
+	stream := false
+	if req.Header.Get("Accept") == "text/event-stream" {
+		defaultFormatter = reader.SSEFormat
+		stream = true
+	}
+
+	opts = append(opts, reader.OptStream(stream))
+
+	r, err := reader.NewLineReader(client, masterURL, mesosID, frameworkID, executorID, containerID,
+		taskPath, file, defaultFormatter, opts...)
+	if err != nil {
+		ERROR(w, err.Error(), http.StatusInternalServerError)
+		logrus.Errorf("unable to initialize files API reader: %s", err)
+		return
+	}
+
+	if req.Header.Get("Accept") != "text/event-stream" {
+		for {
+			_, err := io.Copy(w, r)
+			switch err {
+			case nil:
+				return
+			case reader.ErrNoData:
+				continue
+			default:
+				logrus.Errorf("unexpected error while reading the logs: %s", err)
+				return
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+
+	// Set response headers.
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Transfer-Encoding", "chunked")
+
+	w.Header().Set("X-Accel-Buffering", "no")
+	f := w.(http.Flusher)
+	notify := w.(http.CloseNotifier).CloseNotify()
+
+	f.Flush()
+	for {
+		select {
+		case <-notify:
+			{
+				logrus.Debugf("Closing a client connection. Request URI: %s", req.RequestURI)
+				return
+			}
+		case <-time.After(time.Microsecond * 100):
+			{
+				io.Copy(w, r)
+				f.Flush()
+			}
+		}
+	}
+}
+
+func redirectURL(id *nodeutil.CanonicalTaskID, file, RawQuery string) (string, error) {
+	// find if the task is standalone of a pod.
+	isPod := id.ExecutorID != ""
+	executorID := id.ExecutorID
+	if !isPod {
+		executorID = id.ID
+	}
+
+	// take the last element
+	taskID := id.ContainerIDs[len(id.ContainerIDs)-1]
+	taskLogURL := fmt.Sprintf("%s/%s/logs/v2/task/frameworks/%s/executors/%s/runs/%s/", prefix, id.AgentID,
+		id.FrameworkID, executorID, taskID)
+
+	if isPod {
+		taskLogURL += fmt.Sprintf("/tasks/%s/%s", id.ID, file)
+	} else {
+		taskLogURL += file
+	}
+
+	if RawQuery != "" {
+		taskLogURL += "?" + RawQuery
+	}
+
+	return taskLogURL, nil
+}
+
+func discover(w http.ResponseWriter, req *http.Request) {
+	nodeInfo, ok := middleware.FromContextNodeInfo(req.Context())
+	if !ok {
+		ERROR(w, "invalid context, unable to retrieve a nodeInfo object", http.StatusInternalServerError)
+		return
+	}
+
+	vars := mux.Vars(req)
+	taskID := vars["taskID"]
+	file := vars["file"]
+
+	if file == "" {
+		file = "stdout"
+	}
+
+	if taskID == "" {
+		logrus.Error("taskID is empty")
+		ERROR(w, "taskID is empty", http.StatusInternalServerError)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// try to get the canonical ID for a running task first.
+	var (
+		canonicalTaskID *nodeutil.CanonicalTaskID
+		err             error
+	)
+
+	// TODO: expose this option to a user.
+	for _, completed := range []bool{false, true} {
+		canonicalTaskID, err = nodeInfo.TaskCanonicalID(ctx, taskID, completed)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get canonical task ID: %s", err)
+		ERROR(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	taskURL, err := redirectURL(canonicalTaskID, file, req.URL.RawQuery)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to build redirect URL: %s", err)
+		ERROR(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, req, taskURL, http.StatusSeeOther)
+}

--- a/dcos-log/api/v2/routes.go
+++ b/dcos-log/api/v2/routes.go
@@ -22,4 +22,10 @@ func InitRoutes(v2 *mux.Router, cfg *config.Config, client *http.Client, nodeInf
 
 	v2.Path("/task/{taskID}").Handler(wrappedDiscoverHandler).Methods("GET")
 	v2.Path("/task/{taskID}/file/{file}").Handler(wrappedDiscoverHandler).Methods("GET")
+
+	componentHandler := http.HandlerFunc(journalHandler)
+	wrappedComponentHandler := middleware.Wrapped(componentHandler, cfg, client, nodeInfo)
+
+	v2.Path("/component").Handler(wrappedComponentHandler).Methods("GET")
+	v2.Path("/component/{name}").Handler(wrappedComponentHandler).Methods("GET")
 }

--- a/dcos-log/api/v2/routes.go
+++ b/dcos-log/api/v2/routes.go
@@ -1,0 +1,25 @@
+package v2
+
+import (
+	"net/http"
+
+	"github.com/dcos/dcos-go/dcos/nodeutil"
+	"github.com/dcos/dcos-log/dcos-log/api/middleware"
+	"github.com/dcos/dcos-log/dcos-log/config"
+	"github.com/gorilla/mux"
+)
+
+// InitRoutes inits the v1 logging routes
+func InitRoutes(v2 *mux.Router, cfg *config.Config, client *http.Client, nodeInfo nodeutil.NodeInfo) {
+	taskLogHandler := http.HandlerFunc(filesAPIHandler)
+	wrappedTaskLogHandler := middleware.Wrapped(taskLogHandler, cfg, client, nodeInfo)
+
+	v2.Path("/task/frameworks/{frameworkID}/executors/{executorID}/runs/{containerID}/{file}").Handler(wrappedTaskLogHandler).Methods("GET")
+	v2.Path("/task/frameworks/{frameworkID}/executors/{executorID}/runs/{containerID}/tasks/{taskPath}/{file}").Handler(wrappedTaskLogHandler).Methods("GET")
+
+	discoverHandler := http.HandlerFunc(discover)
+	wrappedDiscoverHandler := middleware.Wrapped(discoverHandler, cfg, client, nodeInfo)
+
+	v2.Path("/task/{taskID}").Handler(wrappedDiscoverHandler).Methods("GET")
+	v2.Path("/task/{taskID}/file/{file}").Handler(wrappedDiscoverHandler).Methods("GET")
+}

--- a/dcos-log/journal/reader/config.go
+++ b/dcos-log/journal/reader/config.go
@@ -112,10 +112,7 @@ func OptionSince(d time.Duration) Option {
 			return ErrInvalidDuration
 		}
 		start := time.Now().Add(-d)
-		if err := r.Journal.SeekRealtimeUsec(uint64(start.UnixNano() / 1000)); err != nil {
-			return err
-		}
-		return nil
+		return r.Journal.SeekRealtimeUsec(uint64(start.UnixNano() / 1000))
 	}
 }
 

--- a/dcos-log/mesos/files/reader/format.go
+++ b/dcos-log/mesos/files/reader/format.go
@@ -31,7 +31,7 @@ func SSEFormat(l Line, rm *ReadManager) (output string) {
 	return output
 }
 
-// LineFormat is a simple \n separates format.
+// LineFormat is a simple \readLimit separates format.
 func LineFormat(l Line, rm *ReadManager) string {
 	return l.Message + "\n"
 }

--- a/dcos-log/mesos/files/reader/format.go
+++ b/dcos-log/mesos/files/reader/format.go
@@ -1,0 +1,21 @@
+package reader
+
+import "fmt"
+
+// Formatter is an interface for formatter functions.
+type Formatter func(l Line) string
+
+// SSEFormat implement server sent events format.
+func SSEFormat(l Line) (output string) {
+	if l.Offset > 0 && l.Size > 0 {
+		output += fmt.Sprintf("id: %d\n", l.Offset+l.Size)
+	}
+
+	output += fmt.Sprintf("data: %s\n\n", l.Message)
+	return output
+}
+
+// LineFormat is a simple \n separates format.
+func LineFormat(l Line) string {
+	return l.Message + "\n"
+}

--- a/dcos-log/mesos/files/reader/format.go
+++ b/dcos-log/mesos/files/reader/format.go
@@ -1,21 +1,56 @@
 package reader
 
-import "fmt"
+import (
+	"fmt"
+	"encoding/json"
+	"github.com/Sirupsen/logrus"
+)
 
 // Formatter is an interface for formatter functions.
-type Formatter func(l Line) string
+type Formatter func(l Line, rm *ReadManager) string
 
 // SSEFormat implement server sent events format.
-func SSEFormat(l Line) (output string) {
-	if l.Offset > 0 && l.Size > 0 {
-		output += fmt.Sprintf("id: %d\n", l.Offset+l.Size)
+func SSEFormat(l Line, rm *ReadManager) (output string) {
+
+	var line Line
+	// try using the json in response
+	jsonLine, err := jsonifyLine(l, rm)
+	if err == nil {
+		line = *jsonLine
+	} else {
+		logrus.Errorf("error getting structured message, falling back to simple text")
+		line = l
 	}
 
-	output += fmt.Sprintf("data: %s\n\n", l.Message)
+	if line.Offset > 0 && line.Size > 0 {
+		output += fmt.Sprintf("id: %d\n", line.Offset+line.Size)
+	}
+
+	output += fmt.Sprintf("data: %s\n\n", line.Message)
 	return output
 }
 
 // LineFormat is a simple \n separates format.
-func LineFormat(l Line) string {
+func LineFormat(l Line, rm *ReadManager) string {
 	return l.Message + "\n"
+}
+
+func jsonifyLine(l Line, rm *ReadManager) (*Line, error) {
+	msg := l.Message
+	structMsg := struct {
+		Fields map[string]interface{} `json:"fields"`
+	} {
+		Fields: map[string]interface{}{"MESSAGE": msg, "AGENT_ID": rm.agentID, "EXECUTOR_ID": rm.executorID,
+			"FRAMEWORK_ID": rm.frameworkID, "CONTAINER_ID": rm.containerID, "FILE": rm.file},
+	}
+
+	marshaledStructMessage, err := json.Marshal(structMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	newLine := l
+	newLine.Message = string(marshaledStructMessage)
+
+	return &newLine, nil
 }

--- a/dcos-log/mesos/files/reader/format.go
+++ b/dcos-log/mesos/files/reader/format.go
@@ -1,8 +1,9 @@
 package reader
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -39,7 +40,7 @@ func jsonifyLine(l Line, rm *ReadManager) (*Line, error) {
 	msg := l.Message
 	structMsg := struct {
 		Fields map[string]interface{} `json:"fields"`
-	} {
+	}{
 		Fields: map[string]interface{}{"MESSAGE": msg, "AGENT_ID": rm.agentID, "EXECUTOR_ID": rm.executorID,
 			"FRAMEWORK_ID": rm.frameworkID, "CONTAINER_ID": rm.containerID, "FILE": rm.file},
 	}

--- a/dcos-log/mesos/files/reader/line.go
+++ b/dcos-log/mesos/files/reader/line.go
@@ -1,0 +1,8 @@
+package reader
+
+// Line is a structure for a line message with offset.
+type Line struct {
+	Message string
+	Offset  int
+	Size    int
+}

--- a/dcos-log/mesos/files/reader/option.go
+++ b/dcos-log/mesos/files/reader/option.go
@@ -13,7 +13,7 @@ type Option func(*ReadManager) error
 // OptLines limits a number of lines to be returned to a client.
 func OptLines(n int) Option {
 	return func(rm *ReadManager) error {
-		rm.n = n
+		rm.readLimit = n
 		return nil
 	}
 }
@@ -62,7 +62,7 @@ func OptStream(stream bool) Option {
 func OptOffset(offset int) Option {
 	return func(rm *ReadManager) error {
 		if offset < 0 {
-			return fmt.Errorf("invalid offset %d. Must be positive integer", offset)
+			return fmt.Errorf("invalid offset %d. Must be zero or positive integer", offset)
 		}
 		rm.offset = offset
 		return nil
@@ -72,7 +72,7 @@ func OptOffset(offset int) Option {
 // OptReadFromEnd moves the cursor to the end of file.
 func OptReadFromEnd() Option {
 	return func(rm *ReadManager) error {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 
 		offset, err := rm.fileLen(ctx)

--- a/dcos-log/mesos/files/reader/option.go
+++ b/dcos-log/mesos/files/reader/option.go
@@ -1,0 +1,85 @@
+package reader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Option is a functional parameters interface.
+type Option func(*ReadManager) error
+
+// OptLines limits a number of lines to be returned to a client.
+func OptLines(n int) Option {
+	return func(rm *ReadManager) error {
+		rm.n = n
+		return nil
+	}
+}
+
+// OptSkip skips the number of lines.
+func OptSkip(n int) Option {
+	return func(rm *ReadManager) error {
+		rm.skip = n
+		return nil
+	}
+}
+
+// OptFile sets the filename to read.
+func OptFile(f string) Option {
+	return func(rm *ReadManager) error {
+		rm.File = f
+		return nil
+	}
+}
+
+// OptHeaders sets the optional request header.
+func OptHeaders(h http.Header) Option {
+	return func(rm *ReadManager) error {
+		rm.header = h
+		return nil
+	}
+}
+
+// OptReadDirection sets the direction the journal must be read.
+func OptReadDirection(r ReadDirection) Option {
+	return func(rm *ReadManager) error {
+		rm.readDirection = r
+		return nil
+	}
+}
+
+// OptStream sets the flag to stream the logs. (do not close the connection)
+func OptStream(stream bool) Option {
+	return func(rm *ReadManager) error {
+		rm.stream = stream
+		return nil
+	}
+}
+
+// OptOffset sets the offset in the file.
+func OptOffset(offset int) Option {
+	return func(rm *ReadManager) error {
+		if offset < 0 {
+			return fmt.Errorf("invalid offset %d. Must be positive integer", offset)
+		}
+		rm.offset = offset
+		return nil
+	}
+}
+
+// OptReadFromEnd moves the cursor to the end of file.
+func OptReadFromEnd() Option {
+	return func(rm *ReadManager) error {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+
+		offset, err := rm.fileLen(ctx)
+		if err != nil {
+			return err
+		}
+
+		return OptOffset(offset)(rm)
+	}
+}

--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -1,0 +1,351 @@
+package reader
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+const (
+	chunkSize = 1 << 16
+)
+
+var (
+	// ErrEmptyParam returned by NewLineReader if empty arguments passed.
+	ErrEmptyParam = errors.New("args cannot be empty")
+
+	// ErrNoData is an error returned by Read(). It indicates that the buffer is empty
+	// and we need to request more data from mesos files API.
+	ErrNoData = errors.New("new data needed")
+)
+
+type response struct {
+	Data   string `json:"data"`
+	Offset int    `json:"offset"`
+}
+
+type modifier func(s string) string
+
+func notEmpty(args []string) error {
+	if len(args) == 0 {
+		return ErrEmptyParam
+	}
+
+	for _, arg := range args {
+		if arg == "" {
+			return ErrEmptyParam
+		}
+	}
+
+	return nil
+}
+
+// NewLineReader is a ReadManager constructor.
+func NewLineReader(client *http.Client, masterURL url.URL, agentID, frameworkID, executorID, containerID, taskPath, file string,
+	format Formatter, opts ...Option) (*ReadManager, error) {
+
+	// make sure the required parameters are set properly
+	if err := notEmpty([]string{agentID, frameworkID, executorID, containerID}); err != nil {
+		return nil, err
+	}
+
+	sandboxPath := fmt.Sprintf("/var/lib/mesos/slave/slaves/%s/frameworks/%s/executors/%s/runs/%s/", agentID, frameworkID, executorID, containerID)
+	if taskPath != "" {
+		sandboxPath += fmt.Sprintf("tasks/%s/", taskPath)
+	}
+
+	rm := &ReadManager{
+		client: client,
+
+		File:         file,
+		readEndpoint: masterURL,
+		sandboxPath:  sandboxPath,
+		formatFn:     format,
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(rm); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if rm.readDirection == BottomToTop && rm.skip != 0 {
+		var (
+			foundLines int
+			offset int
+			length int
+		)
+
+		if rm.offset > chunkSize {
+			offset = rm.offset - chunkSize
+			length = chunkSize
+		} else {
+			// offset 0
+			length = rm.offset
+		}
+
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+			lines, delta, err := rm.read(ctx, offset, length, reverse)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+
+			cancel()
+
+			skip := rm.skip
+
+			// make skip a positive number
+			if skip < 0 {
+				skip = rm.skip * -1
+			}
+
+			// if the required number of lines found, we need to calculate an offset
+			if foundLines+len(lines) >= skip {
+				for i, skipped := 0, 0; skipped < skip; i++ {
+					if lines[i].Message != "" {
+						skipped++
+					}
+					rm.offset -= len(lines[i].Message) + 1
+				}
+				break
+			} else {
+				// if the current chunk contains less then requested lines, then add to a counter
+				// and continue search.
+				foundLines += len(lines)
+			}
+
+			length = chunkSize
+			offset -= chunkSize - delta
+			rm.offset = offset
+
+			// if the offset is 0 or negative value, the means we reached the top of the file.
+			// we can just set the offset to 0 and read the entire file
+			if offset < 0 {
+				rm.offset = 0
+				break
+			}
+		}
+	}
+
+	// guard against negative offset
+	if rm.offset < 0 {
+		rm.offset = 0
+	}
+
+	return rm, nil
+}
+
+// ReadDirection specifies the direction files API will be read.
+type ReadDirection int
+
+const (
+	// TopToBottom reads files API from top to bottom.
+	TopToBottom ReadDirection = iota
+
+	// BottomToTop reads files API from bottom to top.
+	BottomToTop
+)
+
+// ReadManager is a mesos files API reader. It reads builds the correct sandbox path to files
+// and implements io.Reader.
+// http://mesos.apache.org/documentation/latest/endpoints/files/read/
+type ReadManager struct {
+	client       *http.Client
+	readEndpoint url.URL
+	sandboxPath  string
+	header       http.Header
+
+	readDirection ReadDirection
+	n             int
+	skip          int
+	skipped       int
+	File          string
+
+	size   int
+	offset int
+	lines  []Line
+
+	readLines int
+	stream    bool
+
+	formatFn Formatter
+}
+
+func (rm *ReadManager) do(req *http.Request) (*response, error) {
+	resp, err := rm.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad status %d", resp.StatusCode)
+	}
+
+	data := &response{}
+	if err := json.NewDecoder(resp.Body).Decode(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (rm *ReadManager) fileLen(ctx context.Context) (int, error) {
+	v := url.Values{}
+	v.Add("path", rm.sandboxPath+rm.File)
+	v.Add("offset", "-1")
+	newURL := rm.readEndpoint
+	newURL.RawQuery = v.Encode()
+
+	logrus.Info(newURL.String())
+	req, err := http.NewRequest("GET", newURL.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header = rm.header
+
+	resp, err := rm.do(req.WithContext(ctx))
+	if err != nil {
+		return 0, err
+	}
+
+	return resp.Offset, nil
+}
+
+func (rm *ReadManager) read(ctx context.Context, offset, length int, modifier modifier) ([]Line, int, error) {
+	v := url.Values{}
+	v.Add("path", rm.sandboxPath+rm.File)
+	v.Add("offset", strconv.Itoa(offset))
+	v.Add("length", strconv.Itoa(length))
+
+	if modifier == nil {
+		modifier = func(s string) string { return s }
+	}
+
+	newURL := rm.readEndpoint
+	newURL.RawQuery = v.Encode()
+
+	logrus.Info(newURL.String())
+
+	req, err := http.NewRequest("GET", newURL.String(), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req.Header = rm.header
+	resp, err := rm.do(req.WithContext(ctx))
+	if err != nil {
+		return nil, 0, err
+	}
+	lines := strings.Split(modifier(resp.Data), "\n")
+
+	delta := 0
+	if len(lines) > 1 {
+		delta = len(lines[len(lines)-1])
+		lines = lines[:len(lines)-1]
+	}
+
+	linesWithOffset := make([]Line, len(lines))
+	// accumulates the position of the line + \n
+	accumulator := 0
+	for i := 0; i < len(lines); i++ {
+		linesWithOffset[i] = Line{
+			Message: lines[i],
+			Offset:  offset + accumulator,
+			Size:    len(lines[i]),
+		}
+		accumulator += len(lines[i]) + 1
+	}
+
+	return linesWithOffset, delta, nil
+}
+
+// Prepand the lines to a buffer.
+func (rm *ReadManager) Prepand(s Line) {
+	if s.Message == "" {
+		return
+	}
+	old := rm.lines
+	rm.lines = append([]Line{s}, old...)
+}
+
+// Pop returns a line from the end of the buffer.
+func (rm *ReadManager) Pop() *Line {
+	old := *rm
+	n := len(old.lines)
+	if n == 0 {
+		return nil
+	}
+
+	x := old.lines[n-1]
+	rm.lines = old.lines[0 : n-1]
+	return &x
+}
+
+// Read implements io.Reader interface.
+func (rm *ReadManager) Read(b []byte) (int, error) {
+start:
+	if !rm.stream && rm.n > 0 && rm.readLines == rm.n {
+		return 0, io.EOF
+	}
+
+	if len(rm.lines) == 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+
+		lines, delta, err := rm.read(ctx, rm.offset, chunkSize, nil)
+		if err != nil {
+			return 0, err
+		}
+
+		if len(lines) > 1 {
+			linesLen := 0
+			for _, line := range lines {
+				rm.Prepand(line)
+				linesLen += len(line.Message) + 1
+			}
+
+			if linesLen < chunkSize {
+				rm.offset = rm.offset + linesLen - 1
+			} else {
+				rm.offset = (rm.offset + chunkSize) - delta - 1
+			}
+		} else {
+			return 0, io.EOF
+		}
+	}
+
+	line := rm.Pop()
+	if line == nil {
+		return 0, ErrNoData
+	}
+
+	if rm.skip > 0 && rm.skipped < rm.skip {
+		rm.skipped++
+		goto start
+	}
+
+	rm.readLines++
+	return strings.NewReader(rm.formatFn(*line)).Read(b)
+}
+
+func reverse(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}

--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -71,11 +71,11 @@ func NewLineReader(client *http.Client, masterURL url.URL, agentID, frameworkID,
 		sandboxPath:  sandboxPath,
 		formatFn:     format,
 
-		agentID: agentID,
+		agentID:     agentID,
 		frameworkID: frameworkID,
-		executorID: executorID,
+		executorID:  executorID,
 		containerID: containerID,
-		file: file,
+		file:        file,
 	}
 
 	for _, opt := range opts {
@@ -89,8 +89,8 @@ func NewLineReader(client *http.Client, masterURL url.URL, agentID, frameworkID,
 	if rm.readDirection == BottomToTop && rm.skip != 0 {
 		var (
 			foundLines int
-			offset int
-			length int
+			offset     int
+			length     int
 		)
 
 		if rm.offset > chunkSize {
@@ -189,12 +189,12 @@ type ReadManager struct {
 
 	formatFn Formatter
 
-	agentID string
+	agentID     string
 	frameworkID string
-	executorID string
+	executorID  string
 	containerID string
-	taskPath string
-	file string
+	taskPath    string
+	file        string
 }
 
 func (rm *ReadManager) do(req *http.Request) (*response, error) {

--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -70,6 +70,12 @@ func NewLineReader(client *http.Client, masterURL url.URL, agentID, frameworkID,
 		readEndpoint: masterURL,
 		sandboxPath:  sandboxPath,
 		formatFn:     format,
+
+		agentID: agentID,
+		frameworkID: frameworkID,
+		executorID: executorID,
+		containerID: containerID,
+		file: file,
 	}
 
 	for _, opt := range opts {
@@ -182,6 +188,13 @@ type ReadManager struct {
 	stream    bool
 
 	formatFn Formatter
+
+	agentID string
+	frameworkID string
+	executorID string
+	containerID string
+	taskPath string
+	file string
 }
 
 func (rm *ReadManager) do(req *http.Request) (*response, error) {
@@ -339,7 +352,7 @@ start:
 	}
 
 	rm.readLines++
-	return strings.NewReader(rm.formatFn(*line)).Read(b)
+	return strings.NewReader(rm.formatFn(*line, rm)).Read(b)
 }
 
 func reverse(s string) string {

--- a/dcos-log/mesos/files/reader/read_test.go
+++ b/dcos-log/mesos/files/reader/read_test.go
@@ -57,7 +57,7 @@ func createHandler(data []byte, t *testing.T) http.HandlerFunc {
 	}
 }
 
-func newServer(t *testing.T, data []byte, opts ...Option) []byte {
+func doRead(t *testing.T, data []byte, opts ...Option) []byte {
 	ts := httptest.NewServer(createHandler(data, t))
 	defer ts.Close()
 
@@ -83,7 +83,7 @@ func newServer(t *testing.T, data []byte, opts ...Option) []byte {
 }
 
 func TestRangeRead(t *testing.T) {
-	buf := newServer(t, data)
+	buf := doRead(t, data)
 	if bytes.Compare(buf, data) != 0 {
 		t.Fatalf("expect %s. Got %s", data, buf)
 	}
@@ -95,7 +95,7 @@ three
 four
 five
 `)
-	buf := newServer(t, data, OptSkip(1))
+	buf := doRead(t, data, OptSkip(1))
 	if bytes.Compare(buf, expectedResponse) != 0 {
 		t.Fatalf("expect response %s. Got %s", expectedResponse, buf)
 	}
@@ -106,7 +106,7 @@ func TestLast2Lines(t *testing.T) {
 five
 `)
 
-	buf := newServer(t, data, OptReadFromEnd(), OptSkip(-2), OptReadDirection(BottomToTop))
+	buf := doRead(t, data, OptReadFromEnd(), OptSkip(-2), OptReadDirection(BottomToTop))
 	if bytes.Compare(buf, expectedResponse) != 0 {
 		t.Fatalf("expect response %s. Got %s", expectedResponse, buf)
 	}
@@ -116,7 +116,7 @@ func TestLimit(t *testing.T) {
 	expectedResponse := []byte(`one
 two
 `)
-	buf := newServer(t, data, OptLines(2))
+	buf := doRead(t, data, OptLines(2))
 	if bytes.Compare(buf, expectedResponse) != 0 {
 		t.Fatalf("expect %s. Got %s", expectedResponse, buf)
 	}
@@ -126,7 +126,18 @@ func TestCursor(t *testing.T) {
 	expectedResponse := []byte(`four
 five
 `)
-	buf := newServer(t, data, OptOffset(14))
+	buf := doRead(t, data, OptOffset(14))
+	if bytes.Compare(buf, expectedResponse) != 0 {
+		t.Fatalf("expect %s. Got %s", expectedResponse, buf)
+	}
+}
+
+func TestLimitAndSkip(t *testing.T) {
+	expectedResponse := []byte(`three
+four
+`)
+
+	buf := doRead(t, data, OptSkip(2), OptLines(2))
 	if bytes.Compare(buf, expectedResponse) != 0 {
 		t.Fatalf("expect %s. Got %s", expectedResponse, buf)
 	}

--- a/dcos-log/mesos/files/reader/read_test.go
+++ b/dcos-log/mesos/files/reader/read_test.go
@@ -1,0 +1,133 @@
+package reader
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+var (
+	data = []byte(`one
+two
+three
+four
+five
+`)
+)
+
+func createHandler(data []byte, t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		d := data
+		// check the correct offset
+		offsetStr := r.URL.Query().Get("offset")
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// handle the file len request
+		if offset == -1 {
+			offset = len(data)
+			d = []byte{}
+		} else if offset >= len(data) {
+			d = []byte{}
+		} else {
+			d = data[offset:]
+			//fmt.Printf("Data offset: %s", data[offset:])
+		}
+
+		resp := &response{
+			Data:   string(d),
+			Offset: offset,
+		}
+
+		marshaledResp, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		io.Copy(w, bytes.NewReader(marshaledResp))
+	}
+}
+
+func newServer(t *testing.T, data []byte, opts ...Option) []byte {
+	ts := httptest.NewServer(createHandler(data, t))
+	defer ts.Close()
+
+	client := &http.Client{}
+
+	masterURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewLineReader(client, *masterURL, "1", "2", "3", "4", "",
+		"stdout", LineFormat, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return buf
+}
+
+func TestRangeRead(t *testing.T) {
+	buf := newServer(t, data)
+	if bytes.Compare(buf, data) != 0 {
+		t.Fatalf("expect %s. Got %s", data, buf)
+	}
+}
+
+func TestSkip(t *testing.T) {
+	expectedResponse := []byte(`two
+three
+four
+five
+`)
+	buf := newServer(t, data, OptSkip(1))
+	if bytes.Compare(buf, expectedResponse) != 0 {
+		t.Fatalf("expect response %s. Got %s", expectedResponse, buf)
+	}
+}
+
+func TestLast2Lines(t *testing.T) {
+	expectedResponse := []byte(`four
+five
+`)
+
+	buf := newServer(t, data, OptReadFromEnd(), OptSkip(-2), OptReadDirection(BottomToTop))
+	if bytes.Compare(buf, expectedResponse) != 0 {
+		t.Fatalf("expect response %s. Got %s", expectedResponse, buf)
+	}
+}
+
+func TestLimit(t *testing.T) {
+	expectedResponse := []byte(`one
+two
+`)
+	buf := newServer(t, data, OptLines(2))
+	if bytes.Compare(buf, expectedResponse) != 0 {
+		t.Fatalf("expect %s. Got %s", expectedResponse, buf)
+	}
+}
+
+func TestCursor(t *testing.T) {
+	expectedResponse := []byte(`four
+five
+`)
+	buf := newServer(t, data, OptOffset(14))
+	if bytes.Compare(buf, expectedResponse) != 0 {
+		t.Fatalf("expect %s. Got %s", expectedResponse, buf)
+	}
+}

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/README.md
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/README.md
@@ -10,6 +10,8 @@ dcos-go/dcos/nodeutil provides a golang interface to DC/OS cluster.
 - `MesosID(*context.Context)` returns a node's mesos ID. Optionally can accept an instance of Context to control
   request cancellation from a caller.
 - `ClusterID()` returns a UUID of a cluster.
+- `TaskCanonicalID(context.Context, task)` returns a canonical node ID for a given task.
+  This includes the mesos agent, framework, executor and container IDs.
 
 Note: Methods `IsLeader()` and `ClusterID()` will only work on master nodes.
 
@@ -57,4 +59,3 @@ func main() {
     }
 }
 ```
-

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/mesos.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/mesos.go
@@ -1,0 +1,84 @@
+package nodeutil
+
+import "errors"
+
+// ErrContainerIDNotFound is returned by ContainerIDs() function if the container id is not set.
+var ErrContainerIDNotFound = errors.New("invalid task. Container ID not found")
+
+// State stands for mesos state.json available via /mesos/master/state.json
+type State struct {
+	ID         string      `json:"id"`
+	Slaves     []Slave     `json:"slaves"`
+	Frameworks []Framework `json:"frameworks"`
+}
+
+// Slave is a field in state.json
+type Slave struct {
+	ID       string `json:"id"`
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+	Pid      string `json:"pid"`
+}
+
+// Framework is a field in state.json
+type Framework struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	PID            string `json:"pid"`
+	Role           string `json:"role"`
+	Tasks          []Task `json:"tasks"`
+	CompletedTasks []Task `json:"completed_tasks"`
+}
+
+// Task is a field in state.json
+type Task struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	FrameworkID string `json:"framework_id"`
+	ExecutorID  string `json:"executor_id"`
+	SlaveID     string `json:"slave_id"`
+	State       string `json:"state"`
+	Role        string `json:"role"`
+
+	Statuses []Status `json:"statuses"`
+}
+
+// Status is a field in state.json
+type Status struct {
+	ContainerStatus ContainerStatus `json:"container_status"`
+}
+
+// ContainerStatus is a field in state.json
+type ContainerStatus struct {
+	ContainerID NestedValue `json:"container_id"`
+}
+
+// NestedValue represents a nested container ID. The value is the actual container ID
+// and Parent is a reference to another NestedValue structure.
+type NestedValue struct {
+	Value  string       `json:"value"`
+	Parent *NestedValue `json:"parent"`
+}
+
+// ContainerIDs returns a slice of container ids , starting with the current,
+// and then appending the parent container ids.
+func (t Task) ContainerIDs() (containerIDs []string, err error) {
+	for _, status := range t.Statuses {
+		containerID := status.ContainerStatus.ContainerID.Value
+		if containerID == "" {
+			return nil, ErrContainerIDNotFound
+		}
+		containerIDs = append(containerIDs, containerID)
+
+		parent := status.ContainerStatus.ContainerID.Parent
+		for parent != nil {
+			containerIDs = append(containerIDs, parent.Value)
+			parent = parent.Parent
+		}
+	}
+
+	if len(containerIDs) == 0 {
+		return nil, ErrContainerIDNotFound
+	}
+	return containerIDs, nil
+}

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -24,6 +25,9 @@ const (
 	defaultClusterIDLocation = "/var/lib/dcos/cluster-id"
 	defaultBashPath          = "/bin/bash"
 )
+
+// ErrTaskNotFound is return if the canonical ID for a given task not found.
+var ErrTaskNotFound = errors.New("task not found")
 
 var defaultStateURL = url.URL{
 	Scheme: "http",
@@ -53,6 +57,16 @@ type NodeInfo interface {
 	IsLeader() (bool, error)
 	MesosID(context.Context) (string, error)
 	ClusterID() (string, error)
+	TaskCanonicalID(ctx context.Context, task string, completed bool) (*CanonicalTaskID, error)
+}
+
+// CanonicalTaskID is a unique task id.
+type CanonicalTaskID struct {
+	ID           string
+	AgentID      string
+	FrameworkID  string
+	ExecutorID   string
+	ContainerIDs []string
 }
 
 // dcosInfo is implementation of NodeInfo interface.
@@ -138,7 +152,9 @@ func (d *dcosInfo) DetectIP() (net.IP, error) {
 		return nil, err
 	}
 
-	ce, err := exec.Run(defaultBashPath, []string{d.detectIPLocation}, exec.Timeout(d.detectIPTimeout))
+	ctx, cancel := context.WithTimeout(context.Background(), d.detectIPTimeout)
+	defer cancel()
+	ce, err := exec.Run(ctx, defaultBashPath, []string{d.detectIPLocation})
 	if err != nil {
 		return nil, err
 	}
@@ -238,44 +254,8 @@ func (d *dcosInfo) MesosID(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("GET", d.mesosStateURL, nil)
+	state, err := d.state(ctx)
 	if err != nil {
-		return "", err
-	}
-
-	if ctx != nil {
-		if header, ok := HeaderFromContext(ctx); ok {
-			req.Header = header
-		}
-		req = req.WithContext(ctx)
-	}
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", ErrNodeInfo{fmt.Sprintf("GET request to %s returned response code %d", d.mesosStateURL, resp.StatusCode)}
-	}
-
-	type stateJSON struct {
-		// top level ID is used for mesos master ID.
-		ID     string `json:"id"`
-		Slaves []struct {
-			ID  string `json:"id"`
-			Pid string `json:"pid"`
-		} `json:"slaves"`
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var state stateJSON
-	if err := json.Unmarshal(body, &state); err != nil {
 		return "", err
 	}
 
@@ -364,6 +344,80 @@ func (d *dcosInfo) ClusterID() (string, error) {
 	}
 
 	return clusterID, nil
+}
+
+func (d *dcosInfo) state(ctx context.Context) (state State, err error) {
+	req, err := http.NewRequest("GET", d.mesosStateURL, nil)
+	if err != nil {
+		return state, err
+	}
+
+	if ctx != nil {
+		if header, ok := HeaderFromContext(ctx); ok {
+			req.Header = header
+		}
+		req = req.WithContext(ctx)
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return state, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return state, ErrNodeInfo{fmt.Sprintf("GET request to %s returned response code %d", d.mesosStateURL, resp.StatusCode)}
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&state)
+	return state, err
+}
+
+// TaskCanonicalID return a CanonicalTaskID for a given task.
+func (d *dcosInfo) TaskCanonicalID(ctx context.Context, task string, completed bool) (*CanonicalTaskID, error) {
+	state, err := d.state(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var foundTasks []Task
+	for _, framework := range state.Frameworks {
+		currentTasks := framework.Tasks
+		if completed {
+			currentTasks = framework.CompletedTasks
+		}
+
+		for _, t := range currentTasks {
+			if t.Name != task && !strings.Contains(t.ID, task) {
+				continue
+			}
+			foundTasks = append(foundTasks, t)
+		}
+	}
+
+	if len(foundTasks) == 0 {
+		return nil, ErrTaskNotFound
+	} else if len(foundTasks) > 1 {
+		var taskIDs []string
+		for _, task := range foundTasks {
+			taskIDs = append(taskIDs, task.ID)
+		}
+		return nil, fmt.Errorf("found more then 1 task with name %s: %s", task, taskIDs)
+	}
+
+	t := foundTasks[0]
+	containerIDs, err := t.ContainerIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	return &CanonicalTaskID{
+		ID:           t.ID,
+		AgentID:      t.SlaveID,
+		FrameworkID:  t.FrameworkID,
+		ExecutorID:   t.ExecutorID,
+		ContainerIDs: containerIDs,
+	}, nil
 }
 
 // HeaderFromContext returns http.Header from a context if it's found.

--- a/vendor/github.com/dcos/dcos-go/exec/exec.go
+++ b/vendor/github.com/dcos/dcos-go/exec/exec.go
@@ -1,26 +1,30 @@
 package exec
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"io"
 	"os/exec"
+	"syscall"
 	"time"
 )
 
 // dcos-go/exec is a os/exec wrapper. It implements io.Reader and can be used to read both STDOUT and STDERR.
 //
 // Usage:
-// ce := exec.Run("bash", []string{"infinite.sh"}, exec.Timeout(3 * time.Second))
+// ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+// defer cancel()
+//
+// ce, err := exec.Run(ctx, "bash", []string{"infinite.sh"})
+// if err != nil {
+// 	log.Fatal(err)
+// }
 //
 // io.Copy(os.Stdout, ce)
-// err := <- ce.Done
+// err = <- ce.Done
 // if err != nil {
-// 	log.Error(err)
+// 	log.Fatal(err)
 // }
-
-// ErrInvalidTimeout is the error returned by `func Timeout` if a non-positive timeout option specified.
-var ErrInvalidTimeout = errors.New("Timeout cannot be negative or empty")
 
 // CommandExecutor is a structure returned by exec.Run
 // Cancel can be used by a user to interrupt a command execution.
@@ -30,8 +34,7 @@ var ErrInvalidTimeout = errors.New("Timeout cannot be negative or empty")
 //  <context deadline exceeded> means timeout was reached and command was killed.
 //  <context canceled>  means that command was canceled by a user.
 type CommandExecutor struct {
-	Cancel context.CancelFunc
-	Done   chan error
+	Done chan error
 
 	done chan error
 	pipe *io.PipeReader
@@ -39,42 +42,19 @@ type CommandExecutor struct {
 
 // Read implements the io.Reader.
 // CommandExecutor will read from stdout and stderr
-func (c CommandExecutor) Read(p []byte) (int, error) {
+func (c *CommandExecutor) Read(p []byte) (int, error) {
 	return c.pipe.Read(p)
-}
-
-// Option is a functional option that configures a CommandExecutor
-type Option func(*context.Context, *CommandExecutor) error
-
-// Timeout configures a CommandExecutor with a working Cancel func and the given timeout
-func Timeout(timeout time.Duration) Option {
-	return func(ctx *context.Context, ce *CommandExecutor) error {
-		if timeout <= 0 {
-			return ErrInvalidTimeout
-		}
-		newContext, cancel := context.WithTimeout(*ctx, timeout)
-		*ctx = newContext
-		ce.Cancel = cancel
-		return nil
-	}
 }
 
 // Run spawns the given command and returns a handle to the running process in the form
 // of a CommandExecutor.
-func Run(command string, arg []string, options ...Option) (CommandExecutor, error) {
-	// by default Cancel is spineless unless someone configures an option to enable it
-	commandExecutor := CommandExecutor{Cancel: func() {}, Done: make(chan error, 1), done: make(chan error, 1)}
-	ctx := context.Background()
-
-	// apply options to command executor
-	for _, opt := range options {
-		if opt != nil {
-			err := opt(&ctx, &commandExecutor)
-			if err != nil {
-				return CommandExecutor{}, err
-			}
-		}
+func Run(ctx context.Context, command string, arg []string) (*CommandExecutor, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+
+	// by default Cancel is spineless unless someone configures an option to enable it
+	commandExecutor := &CommandExecutor{Done: make(chan error, 1), done: make(chan error, 1)}
 
 	cmd := exec.CommandContext(ctx, command, arg...)
 	go func() {
@@ -103,4 +83,71 @@ func Run(command string, arg []string, options ...Option) (CommandExecutor, erro
 	}()
 
 	return commandExecutor, nil
+}
+
+func commandParts(command ...string) (name string, arg []string) {
+	if len(command) == 0 {
+		panic("empty command")
+	}
+	return command[0], command[1:]
+}
+
+// Command returns a Cmd from a shell command.
+func Command(command ...string) *exec.Cmd {
+	name, arg := commandParts(command...)
+	return exec.Command(name, arg...)
+}
+
+// CommandContext returns a Cmd with the given context and shell command.
+func CommandContext(ctx context.Context, command ...string) *exec.Cmd {
+	name, arg := commandParts(command...)
+	return exec.CommandContext(ctx, name, arg...)
+}
+
+// FullOutput runs a command and returns its stdout, stderr, exit code, and error status.
+func FullOutput(c *exec.Cmd) (stdout []byte, stderr []byte, code int, err error) {
+	var outbuf, errbuf bytes.Buffer
+
+	c.Stdout = &outbuf
+	c.Stderr = &errbuf
+
+	if err := c.Start(); err != nil {
+		return nil, nil, 0, err
+	}
+
+	err = c.Wait()
+	code, err = exitCode(err)
+	stdout = outbuf.Bytes()
+	stderr = errbuf.Bytes()
+
+	return stdout, stderr, code, err
+}
+
+// SimpleFullOutput runs a shell command with a timeout and returns its stdout, stderr, exit code, and error status.
+func SimpleFullOutput(timeout time.Duration, command ...string) (stdout []byte, stderr []byte, code int, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return FullOutput(CommandContext(ctx, command...))
+}
+
+// exitCode takes an error and checks if it's a read error or program had non zero exit code.
+// The output is the return value and error. The return value must be treated as a real return code value
+// only if error is nil. If error is not nil, it means it's a real error.
+func exitCode(e error) (int, error) {
+	if e == nil {
+		return 0, nil
+	}
+
+	// check if error contains program exit code
+	if exiterr, ok := e.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			// when a program exceeded timeout it will be terminated
+			// and the code -1 will be set.
+			if status.ExitStatus() != -1 {
+				return status.ExitStatus(), nil
+			}
+		}
+	}
+
+	return 0, e
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -43,16 +43,16 @@
 			"revisionTime": "2017-01-19T15:54:30Z"
 		},
 		{
-			"checksumSHA1": "3YuJZ1i8gW1ISvmXxCgkvIa7LkE=",
+			"checksumSHA1": "mACB+AX0KOSEZEM6PeOKbdU721I=",
 			"path": "github.com/dcos/dcos-go/dcos/nodeutil",
-			"revision": "74526af763e046fdbcb9e2ac64fed0bdd9213e0f",
-			"revisionTime": "2017-02-23T00:15:14Z"
+			"revision": "42172ec4c229dde10010d63836a3847b57f0f599",
+			"revisionTime": "2017-11-10T00:56:20Z"
 		},
 		{
-			"checksumSHA1": "ZlJiS1RE06MscHhuI1kYNdJi+Tk=",
+			"checksumSHA1": "H5lLBKWkY3fI0YfusLX/vp7FGJU=",
 			"path": "github.com/dcos/dcos-go/exec",
-			"revision": "7052cb64dd2a18762c9275f0ac1b13d13678eefd",
-			"revisionTime": "2016-11-15T21:18:46Z"
+			"revision": "106806e55a0b8ffd17997e743d4b6d6bb856858e",
+			"revisionTime": "2017-10-25T20:27:21Z"
 		},
 		{
 			"checksumSHA1": "U14VXt9bXlwhVLIIBJDzLpYAZXE=",


### PR DESCRIPTION
Add support for mesos files API.
Newest API v2 will support both component logs (via journald) and task logs (mesos files API).
Change also includes a discovery service, which will provide the canonical task ID based on user's input. Running and Completed tasks are supported. Single tasks and Containers are supported as well.

[design doc](https://docs.google.com/document/d/1Z2gWi1H7lc3nNGqLUU9Hecvm9EyPLI-6t3uK1ANlHyA)