### PR TITLE
fix a one line message bug

### DIFF
--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -256,6 +256,11 @@ func (rm *ReadManager) read(ctx context.Context, offset, length int, modifier mo
 	if err != nil {
 		return nil, 0, err
 	}
+
+	if resp.Data == "" || resp.Data == "\n" {
+		return nil, 0, io.EOF
+	}
+
 	lines := strings.Split(modifier(resp.Data), "\n")
 
 	delta := 0
@@ -317,7 +322,7 @@ start:
 			return 0, err
 		}
 
-		if len(lines) > 1 {
+		if len(lines) > 0 {
 			linesLen := 0
 			for _, line := range lines {
 				rm.Prepend(line)
@@ -329,8 +334,6 @@ start:
 			} else {
 				rm.offset = (rm.offset + chunkSize) - delta - 1
 			}
-		} else {
-			return 0, io.EOF
 		}
 	}
 

--- a/dcos-log/mesos/files/reader/read_test.go
+++ b/dcos-log/mesos/files/reader/read_test.go
@@ -40,7 +40,6 @@ func createHandler(data []byte, t *testing.T) http.HandlerFunc {
 			d = []byte{}
 		} else {
 			d = data[offset:]
-			//fmt.Printf("Data offset: %s", data[offset:])
 		}
 
 		resp := &response{
@@ -140,5 +139,15 @@ four
 	buf := doRead(t, data, OptSkip(2), OptLines(2))
 	if bytes.Compare(buf, expectedResponse) != 0 {
 		t.Fatalf("expect %s. Got %s", expectedResponse, buf)
+	}
+}
+
+func TestOneLine(t *testing.T) {
+	testData:= []byte(`hello
+`)
+
+	buf := doRead(t, testData)
+	if bytes.Compare(buf, testData) != 0 {
+		t.Fatalf("expect %s. Got %s", testData, buf)
 	}
 }

--- a/dcos-log/mesos/files/reader/read_test.go
+++ b/dcos-log/mesos/files/reader/read_test.go
@@ -143,11 +143,26 @@ four
 }
 
 func TestOneLine(t *testing.T) {
-	testData:= []byte(`hello
+	testData := []byte(`hello
 `)
 
 	buf := doRead(t, testData)
 	if bytes.Compare(buf, testData) != 0 {
 		t.Fatalf("expect %s. Got %s", testData, buf)
+	}
+}
+
+func TestEmptyData(t *testing.T) {
+	testData := []byte("")
+
+	buf := doRead(t, testData)
+	if len(buf) > 0 {
+		t.Fatalf("must be empty. Got %s", buf)
+	}
+
+	testData = []byte("\n")
+	buf = doRead(t, testData)
+	if len(buf) > 0 {
+		t.Fatalf("must be empty. Got %s", buf)
 	}
 }


### PR DESCRIPTION
if the file contains just one line, the logging API would send an empty
response. This patch fixes the bug.