### PR TITLE
BottomToTop should not be default direction

### DIFF
--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -24,7 +24,7 @@ const (
 type ReadDirection int
 
 // BottomToTop reads files API from bottom to top.
-const BottomToTop ReadDirection = 0
+const BottomToTop ReadDirection = 1
 
 // ErrNoData is an error returned by Read(). It indicates that the buffer is empty
 // and we need to request more data from mesos files API.


### PR DESCRIPTION
after a refactoring i made `BottomToTop` = 0, which makes it default read
direction. It should not.