### PR TITLE
pass http header for download and browse endpoint

### DIFF
--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -552,7 +552,18 @@ func journalHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func browseFiles(w http.ResponseWriter, req *http.Request) {
-	r, err := setupFilesAPIReader(req, "/files/browse")
+	token, ok := middleware.FromContextToken(req.Context())
+	if !ok {
+		logError(w, req, "unable to get authorization header from a request", http.StatusUnauthorized)
+		return
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", token)
+
+	opts := []reader.Option{reader.OptHeaders(header)}
+
+	r, err := setupFilesAPIReader(req, "/files/browse", opts...)
 	if err != nil {
 		e, ok := err.(errSetupFilesAPIReader)
 		if !ok {
@@ -577,7 +588,18 @@ func browseFiles(w http.ResponseWriter, req *http.Request) {
 }
 
 func downloadFile(w http.ResponseWriter, req *http.Request) {
-	r, err := setupFilesAPIReader(req, "/files/download")
+	token, ok := middleware.FromContextToken(req.Context())
+	if !ok {
+		logError(w, req, "unable to get authorization header from a request", http.StatusUnauthorized)
+		return
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", token)
+
+	opts := []reader.Option{reader.OptHeaders(header)}
+
+	r, err := setupFilesAPIReader(req, "/files/download", opts...)
 	if err != nil {
 		e, ok := err.(errSetupFilesAPIReader)
 		if !ok {

--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -407,7 +407,14 @@ func (rm ReadManager) BrowseSandbox() ([]SandboxFile, error) {
 	newURL := rm.readEndpoint
 	newURL.RawQuery = v.Encode()
 
-	resp, err := rm.client.Get(newURL.String())
+	req, err := http.NewRequest("GET", newURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header = rm.header
+
+	resp, err := rm.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to make a GET request: %s. URL %s", err, newURL.String())
 	}
@@ -434,6 +441,8 @@ func (rm ReadManager) Download() (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a new request to %s: %s", newURL.String(), err)
 	}
+
+	req.Header = rm.header
 
 	return rm.client.Do(req)
 }

--- a/dcos-log/mesos/files/reader/read_test.go
+++ b/dcos-log/mesos/files/reader/read_test.go
@@ -265,3 +265,20 @@ func TestDownload(t *testing.T) {
 		t.Fatalf("expect %s. Got %s", body, buf)
 	}
 }
+
+func TestHeaderSet(t *testing.T) {
+	h := http.Header{}
+	h.Add("foo", "bar")
+
+	opts := []Option{OptHeaders(h)}
+
+	r, err := NewLineReader(http.DefaultClient, url.URL{}, "1", "2", "3", "4",
+		"", "stdout", LineFormat, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.header.Get("foo") != "bar" {
+		t.Fatalf("expected header foo with value bar. Got %+v", r.header)
+	}
+}


### PR DESCRIPTION
in order to work correctly with auth enabled, we need to pass the Authorization header.
This change adds this for download and browse endpoints.