### PR TITLE
minor bug fixes

### DIFF
--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -104,7 +104,8 @@ func setupFilesAPIReader(req *http.Request, urlPath string, opts ...reader.Optio
 	header := http.Header{}
 	header.Set("Authorization", token)
 
-	opts = append(opts, reader.OptHeaders(header))
+	newOpts := []reader.Option{reader.OptHeaders(header)}
+	newOpts = append(newOpts, opts...)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -136,7 +137,8 @@ func setupFilesAPIReader(req *http.Request, urlPath string, opts ...reader.Optio
 		formatter = reader.SSEFormat
 	}
 
-	return reader.NewLineReader(client, *masterURL, mesosID, frameworkID, executorID, containerID, taskPath, file, formatter, opts...)
+	return reader.NewLineReader(client, *masterURL, mesosID, frameworkID, executorID, containerID, taskPath, file, formatter,
+		newOpts...)
 }
 
 func filesAPIHandler(w http.ResponseWriter, req *http.Request) {

--- a/dcos-log/mesos/files/reader/read.go
+++ b/dcos-log/mesos/files/reader/read.go
@@ -239,7 +239,7 @@ func (rm *ReadManager) fileLen(ctx context.Context) (int, error) {
 	newURL := rm.readEndpoint
 	newURL.RawQuery = v.Encode()
 
-	logrus.Debugf("fileLen %s", newURL)
+	logrus.Debugf("fileLen %s", newURL.String())
 	req, err := http.NewRequest("GET", newURL.String(), nil)
 	if err != nil {
 		return 0, err
@@ -267,7 +267,7 @@ func (rm *ReadManager) read(ctx context.Context, offset, length int, modifier mo
 	newURL := rm.readEndpoint
 	newURL.RawQuery = v.Encode()
 
-	logrus.Debugf("read %s", newURL)
+	logrus.Debugf("read %s", newURL.String())
 
 	req, err := http.NewRequest("GET", newURL.String(), nil)
 	if err != nil {
@@ -418,6 +418,9 @@ func (rm ReadManager) BrowseSandbox() ([]SandboxFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to make a GET request: %s. URL %s", err, newURL.String())
 	}
+
+	logrus.Debugf("sandbox browse %s", newURL.String())
+
 	defer resp.Body.Close()
 
 	var files []SandboxFile
@@ -441,6 +444,8 @@ func (rm ReadManager) Download() (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a new request to %s: %s", newURL.String(), err)
 	}
+
+	logrus.Debugf("download %s", newURL.String())
 
 	req.Header = rm.header
 


### PR DESCRIPTION
- set the header option first in the list, since it might be used in other functional parameters
- url.URL does not implement fmt.Stringer, use .String explicitly 