### PR TITLE
close journald properly

### DIFF
--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -507,6 +507,12 @@ func journalHandler(w http.ResponseWriter, req *http.Request) {
 		logError(w, req, "unable to open journald: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	defer func() {
+		err := j.Close()
+		if err != nil {
+			logrus.Errorf("error closing journald: %s", err)
+		}
+	}()
 
 	// Set response headers.
 	w.Header().Set("Content-Type", entryFormatter.GetContentType().String())


### PR DESCRIPTION
unfortunately we forgot to close journald connection in v2 API. This will make dcos-log to hold the open file descriptors forever. This PR fixes this problem in v2 and makes a small refactor around closing journald connection in v1 to make them consistent.

[SOAK-52](https://jira.mesosphere.com/browse/SOAK-52)