### PR TITLE
 handle journal files rotation properly

### DIFF
--- a/dcos-log/api/v1/handlers.go
+++ b/dcos-log/api/v1/handlers.go
@@ -290,10 +290,11 @@ func readJournalHandler(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 		case <-time.After(time.Second):
-			{
-				io.Copy(w, j)
-				f.Flush()
+			err := j.Follow(time.Millisecond * 100, w)
+			if err != nil {
+				logrus.Errorf("error reading journal %s", err)
 			}
+			f.Flush()
 		}
 	}
 }

--- a/dcos-log/api/v1/handlers.go
+++ b/dcos-log/api/v1/handlers.go
@@ -293,6 +293,7 @@ func readJournalHandler(w http.ResponseWriter, req *http.Request) {
 			err := j.Follow(time.Millisecond * 100, w)
 			if err != nil {
 				logrus.Errorf("error reading journal %s", err)
+				return
 			}
 			f.Flush()
 		}

--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -598,6 +598,7 @@ func journalHandler(w http.ResponseWriter, req *http.Request) {
 			err := j.Follow(time.Millisecond * 100, w)
 			if err != nil {
 				logrus.Errorf("error reading journal %s", err)
+				return
 			}
 			f.Flush()
 		}

--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -594,14 +594,12 @@ func journalHandler(w http.ResponseWriter, req *http.Request) {
 				logrus.Debugf("closing a client connection.")
 				return
 			}
-		case <-time.After(time.Second):
-			{
-				_, err := io.Copy(w, j)
-				if err != nil {
-					logrus.Errorf("error while reading journald: %s. Request: %s", err, req.RequestURI)
-				}
-				f.Flush()
+		case <- time.After(time.Second):
+			err := j.Follow(time.Millisecond * 100, w)
+			if err != nil {
+				logrus.Errorf("error reading journal %s", err)
 			}
+			f.Flush()
 		}
 	}
 

--- a/dcos-log/journal/reader/config.go
+++ b/dcos-log/journal/reader/config.go
@@ -5,6 +5,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/Sirupsen/logrus"
 )
 
 var (
@@ -44,9 +47,18 @@ func OptionMatch(m []JournalEntryMatch) Option {
 			return ErrUninitializedReader
 		}
 
-		for _, match := range m {
-			r.Journal.AddMatch(match.String())
+		fn := func(journal *sdjournal.Journal) {
+			for _, match := range m {
+				journal.AddMatch(match.String())
+				logrus.Infof("adding AND match %s", match)
+			}
 		}
+
+		// apply matches for current optional parameter
+		fn(r.Journal)
+
+		// store the function in case we need to re-apply the matches
+		r.matchFns = append(r.matchFns, fn)
 
 		return nil
 	}
@@ -60,10 +72,19 @@ func OptionMatchOR(m []JournalEntryMatch) Option {
 			return ErrUninitializedReader
 		}
 
-		for _, match := range m {
-			r.Journal.AddMatch(match.String())
-			r.Journal.AddDisjunction()
+		fn := func(journal *sdjournal.Journal) {
+			for _, match := range m {
+				journal.AddMatch(match.String())
+				journal.AddDisjunction()
+				logrus.Infof("adding OR match %s", match)
+			}
 		}
+
+		// apply matches for current optional parameter
+		fn(r.Journal)
+
+		// store the function in case we need to re-apply the matches
+		r.matchFns = append(r.matchFns, fn)
 
 		return nil
 	}

--- a/dcos-log/journal/reader/config.go
+++ b/dcos-log/journal/reader/config.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -50,7 +50,6 @@ func OptionMatch(m []JournalEntryMatch) Option {
 		fn := func(journal *sdjournal.Journal) {
 			for _, match := range m {
 				journal.AddMatch(match.String())
-				logrus.Infof("adding AND match %s", match)
 			}
 		}
 

--- a/dcos-log/journal/reader/read.go
+++ b/dcos-log/journal/reader/read.go
@@ -56,6 +56,10 @@ type Reader struct {
 	contentFormatter EntryFormatter
 	// n represents the number of logs read.
 	n uint64
+
+	// matchFns contains a list of match functions the user used in the original constructor.
+	// this is useful to re-apply matches in some cases (for instance journald rotation)
+	matchFns []func(journal *sdjournal.Journal)
 }
 
 // SkipNext skips a journal by n entries forward.

--- a/dcos-log/journal/reader/read.go
+++ b/dcos-log/journal/reader/read.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // ErrUninitializedReader is the error returned by Reader is contentFormatter wasn't initialized.
@@ -274,7 +274,9 @@ func (r *Reader) Follow(wait time.Duration, writer io.Writer) error {
 		// journald was rotated and we are in a brand new log file and we have to read from the beginning.
 
 		// we want to intentionally ignore the error message, since it would indicate rotated systemd file
-		r.SeekCursor(cursor)
+		if err := r.SeekCursor(cursor); err != nil {
+			logrus.Errorf("error search cursor %s. %s", cursor, err)
+		}
 	}
 
 	// other possible statues are

--- a/dcos-log/journal/reader/read.go
+++ b/dcos-log/journal/reader/read.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/Sirupsen/logrus"
 )
 
 // ErrUninitializedReader is the error returned by Reader is contentFormatter wasn't initialized.
@@ -218,4 +219,69 @@ func (r *Reader) Close() error {
 		return ErrUninitializedReader
 	}
 	return r.Journal.Close()
+}
+
+// Follow is a wrapper function, which can be called multiple times to mimic a journal tailing.
+func (r *Reader) Follow(wait time.Duration, writer io.Writer) error {
+	n, err := io.Copy(writer, r)
+	if err != nil && err != io.EOF {
+		return err
+	}
+
+	// if the number of read lines more then 0, we did not reach the journald bottom and can exit early
+	if n > 0 {
+		return nil
+	}
+
+	// if we reached the journald bottom, we'll have to wait and learn the current status of journald
+	// SD_JOURNAL_INVALIDATE indicates that the journald files were removed from the filesystem and now we need to close
+	// the opened files handlers and reopened with original user parameters.
+	// https://www.freedesktop.org/software/systemd/man/sd_journal_get_fd.html#Return%20Value
+	if r.Journal.Wait(wait) == sdjournal.SD_JOURNAL_INVALIDATE {
+		logrus.Infof("SD_JOURNAL_INVALIDATE, reopened journal")
+
+		cursor, err := r.Journal.GetCursor()
+		if err != nil {
+			return fmt.Errorf("unable to get current cursor: %s", err)
+		}
+
+		// close journal to release the file handler
+		err = r.Journal.Close()
+		if err != nil {
+			return fmt.Errorf("unable to close current instance of journald: %s", err)
+		}
+
+		// open a new journald
+		newJournal, err := sdjournal.NewJournal()
+		if err != nil {
+			return fmt.Errorf("unable to open a new instance of journald: %s", err)
+		}
+
+		// apply the original matches to a new instance of journal
+		// we only need to apply the matches since all other user parameters live in the Reader structure which
+		// was not changed.
+		for _, fn := range r.matchFns {
+			fn(newJournal)
+		}
+
+		// update the journal instance
+		r.Journal = newJournal
+
+		// systemd bug has a weird bug in versions < v236 (a fix for the bug https://github.com/systemd/systemd/pull/5580)
+		// it's quite possible to execute the lines in this block, even if the journald files were not rotated.
+		// So we need to know, if we are in the old journald log or a new one. The easiest method would be
+		// to search for the original journald cursor. If we found the cursor, we are in the same log, otherwise
+		// journald was rotated and we are in a brand new log file and we have to read from the beginning.
+
+		// we want to intentionally ignore the error message, since it would indicate rotated systemd file
+		r.SeekCursor(cursor)
+	}
+
+	// other possible statues are
+	// SD_JOURNAL_NOP - means that the journal did not change since the last invocation and we can just exit without
+	// errors.
+	// SD_JOURNAL_APPEND - means that new entries were appended to the end of the journal and next time the client
+	// runs the Follow() function again, they would be displayed. But for now, we can exit without errors.
+
+	return nil
 }

--- a/dcos-log/journal/reader/read_test.go
+++ b/dcos-log/journal/reader/read_test.go
@@ -239,10 +239,7 @@ func TestFollow(t *testing.T) {
 			t.Fatal("too much time to read journal")
 		default:
 			buf := new(bytes.Buffer)
-			err := r.Follow(time.Second, buf)
-			if err != nil {
-				t.Fatal(err)
-			}
+			r.Follow(time.Second, buf)
 
 			entry := &logEntry{}
 			err = json.NewDecoder(buf).Decode(entry)

--- a/dcos-log/journal/reader/read_test.go
+++ b/dcos-log/journal/reader/read_test.go
@@ -208,10 +208,7 @@ func TestFollow(t *testing.T) {
 		for i := 0; i < 10; i++ {
 
 			journal.Send(fmt.Sprintf("test %s - %d", id, i), journal.PriInfo, map[string]string{"TEST_ID": id})
-			select {
-			case <-ack:
-				continue
-			}
+			<-ack
 		}
 		cancel()
 	}()
@@ -242,7 +239,10 @@ func TestFollow(t *testing.T) {
 			t.Fatal("too much time to read journal")
 		default:
 			buf := new(bytes.Buffer)
-			r.Follow(time.Second, buf)
+			err := r.Follow(time.Second, buf)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			entry := &logEntry{}
 			err = json.NewDecoder(buf).Decode(entry)

--- a/dcos-log/journal/reader/read_test.go
+++ b/dcos-log/journal/reader/read_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/journal"
+	"bytes"
+	"context"
+	"io"
 )
 
 func getUniqueString() string {
@@ -193,5 +196,73 @@ func TestOptionMatchOR(t *testing.T) {
 
 	if size != 2 {
 		t.Fatalf("Expecting to find 2 entries, got %d", size)
+	}
+}
+
+func TestFollow(t *testing.T) {
+	id := getUniqueString()
+	ctx, cancel := context.WithCancel(context.Background())
+	ack := make(chan bool)
+
+	go func() {
+		for i := 0; i < 10; i++ {
+
+			journal.Send(fmt.Sprintf("test %s - %d", id, i), journal.PriInfo, map[string]string{"TEST_ID": id})
+			select {
+			case <-ack:
+				continue
+			}
+		}
+		cancel()
+	}()
+
+	r, err := NewReader(FormatJSON{}, OptionMatchOR([]JournalEntryMatch{
+		{
+			Field: "TEST_ID",
+			Value: id,
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type logEntry struct {
+		Fields map[string]string `json:"fields"`
+	}
+
+	messageCounter := 0
+	for {
+		select {
+		case <- ctx.Done():
+			if messageCounter != 10 {
+				t.Fatalf("expecting to validate 10 log entries. Validated only %d", messageCounter)
+			}
+			return
+		case <-time.After(time.Second):
+			t.Fatal("too much time to read journal")
+		default:
+			buf := new(bytes.Buffer)
+			r.Follow(time.Second, buf)
+
+			entry := &logEntry{}
+			err = json.NewDecoder(buf).Decode(entry)
+			if err != nil {
+				if err == io.EOF {
+					continue
+				}
+				t.Fatal(err)
+			}
+			expectedMessage := fmt.Sprintf("test %s - %d", id, messageCounter)
+			if entry.Fields["MESSAGE"] != expectedMessage {
+				t.Fatalf("expecting message %s. Got %s", expectedMessage, entry.Fields["MESSAGE"])
+			}
+			messageCounter++
+
+			select {
+			case ack <- true:
+			case <-time.After(time.Second):
+				t.Fatal("too much time to send ack")
+			}
+		}
 	}
 }


### PR DESCRIPTION
add a new journal reader function `Follow()` which takes a timeout interval and a io.Writer.
The function takes care of tracking if the journald files were rotated due to normal journald rotation policy.
In this case, it will close the rotated file descriptiors and reopened them with original user parameters.

[DCOS_OSS-2132](https://jira.mesosphere.com/browse/DCOS_OSS-2132)