### PR TITLE
Fixed file streaming using the Mesos File API.

### DIFF
--- a/dcos-log/Dockerfile
+++ b/dcos-log/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update && apt-get install -y \
     libsystemd-dev \
     init
 
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 

--- a/dcos-log/api/v2/handlers.go
+++ b/dcos-log/api/v2/handlers.go
@@ -319,7 +319,13 @@ func filesAPIHandler(w http.ResponseWriter, req *http.Request) {
 			}
 		case <-time.After(time.Microsecond * 100):
 			{
-				_, err := io.Copy(w, r)
+				// TODO(rgoegge): This is a temporary fix.
+				// Not ideal, but will feel responsive enough to the enduser for now.
+				// The right fix should be a blocking io.Copy() call until there is data to read.
+				bytes, err := io.Copy(w, r)
+				if bytes == 0 {
+					time.Sleep(time.Second)
+				}
 				if err != nil && err != reader.ErrNoData {
 					logrus.Errorf("error while reading the files API reader: %s. Request: %s", err, req.RequestURI)
 				}


### PR DESCRIPTION
With this commit we address the problems in DCOS-41248.
In order to not overload the Mesos agent with GET requests, we will now
wait one second if we are reading 0 bytes from the Mesos file.

This fix is temporary and not ideal but feels responsive enough to the
enduser and is a better alternative to what we have today.
The right fix here should be a change to the Read semantics so that a
read will block until there is data available.

https://jira.mesosphere.com/browse/DCOS-41248